### PR TITLE
Include component pointers in entitiesWith opApply loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,13 @@ foreach (entity; ecs.entities.entitiesWith!(Position, Renderable))
 }
 ```
 
+```
+foreach (entity, pos, render; ecs.entities.entitiesWith!(Position, Renderable))
+{
+    // pos is equivalent to entity.component!Position
+    // render is equivalent to entity.component!Renderable
+}
+```
 
 ### Systems
 


### PR DESCRIPTION
I noticed a pretty common pattern with `entitiesWith`:

```
foreach(ent ; em.entitiesWith!(A, B, C)) {
    auto a = ent.component!A;
    auto b = ent.component!B;
    auto c = ent.component!C;
    // do something with a, b, and c
}
```

This patch overloads `opApply` so you can (but don't have to) simplify the above to:

```
foreach(ent, a, b, c ; em.entitiesWith!(A, B, C)) {
    // do something with a, b, and c
}
```

Let me know if you think this would be useful.
