### PR TITLE
[DEBUG] Don't fail emitting event with no handler.

### DIFF
--- a/entitysysd/event.d
+++ b/entitysysd/event.d
@@ -175,10 +175,12 @@ public:
     {
         auto eventId = EventCounter!E.getId();
 
-        if (mHandlers.length == 0) // no event-receiver registered yet
+        auto handlerGroup = eventId in mHandlers;
+
+        if (handlerGroup is null) // no event-receiver registered yet
             return;
 
-        foreach (rcv; mHandlers[eventId])
+        foreach (rcv; *handlerGroup)
         {
             // already subscribed
             if (rcv !is null)
@@ -350,4 +352,17 @@ unittest
     assert(testRcv0.str == "hello");
     assert(testRcv1.str == "123456");
     assert(testRcv2.str == "123world");
+}
+
+// validate that sending an event with no registered receivers does not crash
+unittest
+{
+    auto evtManager = new EventManager;
+
+    // registers a handler for StringEvent, but not IntEvent
+    auto testRcv0 = new TestReceiver0(evtManager);
+
+    // a bug caused this to fail when at least 1 receiver was registered but
+    // no receivers were registered for this event type
+    evtManager.emit!IntEvent(123);
 }


### PR DESCRIPTION
Check that there is an entry in the handlers table for the given event
id before trying to pass it on the the handlers.

The previous check (length == 0) was only sufficient to catch the case
where no handlers of _any_ type were registered. It would crash if at
least one kind of handler was registered, but there were no handlers
for the emitted event type.
